### PR TITLE
Use async friendly stacktrace for exception details

### DIFF
--- a/src/AspNetCoreApiUtilities/AspNetCoreApiUtilities.csproj
+++ b/src/AspNetCoreApiUtilities/AspNetCoreApiUtilities.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>Frogvall.AspNetCore.ApiUtilities</RootNamespace>
     <AssemblyName>ApiUtilities</AssemblyName>
     <PackageId>Frogvall.AspNetCore.ApiUtilities</PackageId>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
-    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AspNetCoreApiUtilities/AspNetCoreApiUtilities.csproj
+++ b/src/AspNetCoreApiUtilities/AspNetCoreApiUtilities.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncFriendlyStackTrace" Version="1.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" />

--- a/src/AspNetCoreApiUtilities/AspNetCoreApiUtilities.csproj
+++ b/src/AspNetCoreApiUtilities/AspNetCoreApiUtilities.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>ApiUtilities</AssemblyName>
     <PackageId>Frogvall.AspNetCore.ApiUtilities</PackageId>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AspNetCoreApiUtilities/ExceptionHandling/ApiExceptionHandler.cs
+++ b/src/AspNetCoreApiUtilities/ExceptionHandling/ApiExceptionHandler.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using AsyncFriendlyStackTrace;
 using Frogvall.AspNetCore.ApiUtilities.Exceptions;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
@@ -67,7 +68,7 @@ namespace Frogvall.AspNetCore.ApiUtilities.ExceptionHandling
             if (env.IsDevelopment())
             {
                 error.Message = ex.Message;
-                error.Detail = ex.StackTrace;
+                error.Detail = ex.ToAsyncString();
             }
             else
             {


### PR DESCRIPTION
Added [AsyncFriendlyStackTrace ](https://github.com/aelij/AsyncFriendlyStackTrace) lib to format the exception messages on Development env.

When a request to a web api fails on a development environment in an async method - we get a long callstack with lots of rethrows. Instead we can get a more readable one, with async methods shown as a single line each. [Example](https://github.com/aelij/AsyncFriendlyStackTrace/blob/master/docs/Example1.md).

One more difference is that now the Detail field contains the full exception info, not only the stacktrace. This was introduced mainly because of the AsyncFriendlyStackTrace lib limitations, but it also adds more details about the exception.